### PR TITLE
Exclude epel-relaease

### DIFF
--- a/nethserver-arm-epel.spec
+++ b/nethserver-arm-epel.spec
@@ -4,7 +4,7 @@
 Summary:       NethServer YUM epel repo configuration
 Name:          nethserver-arm-epel
 Version:       7
-Release:       1%{?dist}
+Release:       2%{?dist}
 License:       GPL
 ExclusiveArch: armv7hl
 Source:        %{name}-%{version}.tar.gz

--- a/root/etc/yum.repos.d/epel.repo
+++ b/root/etc/yum.repos.d/epel.repo
@@ -5,3 +5,4 @@ baseurl=https://armv7.dev.centos.org/repodir/epel-pass-1/
 gpgcheck=0
 enablegroups=0
 enabled=1
+exclude=epel-release*


### PR DESCRIPTION
NethServer/arm-dev#41

 It is a automatically included noarch for x86_64 pointing to non existing repositories for armhfp